### PR TITLE
Add patch variable check

### DIFF
--- a/lib/pronto/flay.rb
+++ b/lib/pronto/flay.rb
@@ -27,6 +27,7 @@ module Pronto
     def messages
       nodes.map do |node|
         patch = patch_for_node(node)
+        return unless patch
 
         line = patch.added_lines.find do |added_line|
           added_line.new_lineno == node.line


### PR DESCRIPTION
During the message generation process of the `flay-runner`, requested file by one of the selected  nodes(`node.file`), is not included in the `ruby_patches`. This leads to an exception in consequent use of `patch` variable, that always expects not `nil` value.  