### PR TITLE
fix: add to_s on file pah comparison

### DIFF
--- a/lib/pronto/flay.rb
+++ b/lib/pronto/flay.rb
@@ -47,7 +47,7 @@ module Pronto
 
     def patch_for_node(node)
       ruby_patches.find do |patch|
-        patch.new_file_full_path == node.file
+        patch.new_file_full_path.to_s == node.file.to_s
       end
     end
 


### PR DESCRIPTION
This PR should fix the this issue: https://github.com/prontolabs/pronto-flay/issues/24.

before: 
```
✗ bundle exec pronto run -c origin/master
bundler: failed to load command: pronto (/home/eduardoseifert/.asdf/installs/ruby/3.3.4/bin/pronto)
/home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-flay-0.11.1/lib/pronto/flay.rb:40:in `block in messages': undefined method `added_lines' for nil (NoMethodError)

        line = patch.added_lines.find do |added_line|
                    ^^^^^^^^^^^^
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-flay-0.11.1/lib/pronto/flay.rb:37:in `map'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-flay-0.11.1/lib/pronto/flay.rb:37:in `messages'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-flay-0.11.1/lib/pronto/flay.rb:14:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/runners.rb:20:in `block in run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/runners.rb:13:in `each'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/runners.rb:13:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto.rb:66:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/cli.rb:70:in `block in run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/cli.rb:68:in `chdir'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/lib/pronto/cli.rb:68:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-0.11.2/bin/pronto:6:in `<top (required)>'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/bin/pronto:25:in `load'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/bin/pronto:25:in `<top (required)>'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli/exec.rb:58:in `load'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli/exec.rb:23:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli.rb:451:in `exec'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli.rb:34:in `dispatch'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/cli.rb:28:in `start'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/exe/bundle:28:in `block in <top (required)>'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.9/exe/bundle:20:in `<top (required)>'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `load'
	from /home/eduardoseifert/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `<main>'
```
after:

```
✗ bundle exec pronto run -c origin/master
/home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:34: warning: `Cop.all` is deprecated. Use `Registry.all` instead.

/home/eduardoseifert/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:62: warning: `inspect_file` is deprecated. Use `investigate` instead.

...
```