### PR TITLE
Prepare a new release for Ruby 3.3/3.4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
       fail-fast: false
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pkg/*
+vendor/*
 *.gem
 .bundle
 .DS_Store

--- a/lib/pronto/flay/version.rb
+++ b/lib/pronto/flay/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module FlayVersion
-    VERSION = '0.11.1'.freeze
+    VERSION = '0.12.0'.freeze
   end
 end

--- a/pronto-flay.gemspec
+++ b/pronto-flay.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('pronto', '~> 0.11.0')
   s.add_dependency('flay', '~> 2.8')
+  s.add_development_dependency('base64', '~> 0.2.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
- Bumped version to 0.12.0
- Removed Ruby 2.3 and 2.4 from test matrix
- Added Ruby 3.3 and 3.4 to test matrix
- Added vendor/ to .gitignore

Addresses #26